### PR TITLE
support py3.3-py3.6 and start tx with config

### DIFF
--- a/src/porm/model.py
+++ b/src/porm/model.py
@@ -585,9 +585,12 @@ class DBModel(BaseDBModel, metaclass=DBModelMeta):
 
     @classmethod
     @contextmanager
-    def start_transaction(cls, db=None) -> _transaction:
+    def start_transaction(cls, db: Union[str, dict]=None) -> _transaction:
         cls._check_meta()
-        config = cls._get_db_conf(db=db)
+        if isinstance(db, dict):
+            config = db
+        else:
+            config = cls._get_db_conf(db=db)
         mydb = MyDBApi(config=config)
         with mydb.start_transaction() as _t:
             yield _t

--- a/src/porm/types/core.py
+++ b/src/porm/types/core.py
@@ -229,7 +229,7 @@ class FloatType(IntegerType):
 
 class TimeType(BaseType):
     _TYPE = datetime.time
-    _DEFAULT = datetime.time.fromisoformat('08:00:00')
+    _DEFAULT = parser.isoparser().parse_isotime('08:00:00')
     _FORMAT = '%H:%M:%S'
 
     def __init__(self, *args, **kwargs):
@@ -241,7 +241,7 @@ class TimeType(BaseType):
         super().validate(val)
         if isinstance(val, six.string_types):
             try:
-                val = datetime.time.fromisoformat(val)
+                val = parser.isoparser().parse_isotime(val)
             except Exception:
                 val = parser.parse(val)
         elif isinstance(val, self.type):


### PR DESCRIPTION
1.fromisoformat in datetime package only supported in >= py3.7, isoparser.parse_isotime in dateutil supported in  >= py3.3